### PR TITLE
Improve UI: accessibility, responsiveness, and consistency

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,7 +2,7 @@
     "version": "0.0.1",
     "configurations": [
         {
-            "name": "dev",
+            "name": "start",
             "runtimeExecutable": "yarn",
             "runtimeArgs": ["start"],
             "port": 5173

--- a/src/components/appFooter.tsx
+++ b/src/components/appFooter.tsx
@@ -1,12 +1,12 @@
-import { Box } from "@mui/material";
+import { Box, Link } from "@mui/material";
 import { CONTACT_HREF } from "../utils";
 import { lighten } from "@mui/material/styles";
 
 export function AppFooter() {
     return (
-        <Box sx={(theme) => ({
+        <Box component="footer" sx={(theme) => ({
             height: "80px",
-            color: "black",
+            color: "text.primary",
             backgroundColor: lighten(theme.palette.primary.main, 0.5),
             padding: "10px 20px 10px 20px",
             display: "flex",
@@ -15,10 +15,10 @@ export function AppFooter() {
             borderTop: "1px solid",
             borderColor: theme.palette.divider,
         })}>
-            <Box sx={{ display: "inline-block", fontFamily: "Roboto" }}>
-                <a className="underline inherit-color" href={CONTACT_HREF}>
+            <Box sx={{ display: "inline-block" }}>
+                <Link href={CONTACT_HREF} underline="hover" color="inherit">
                     Kérdésed van? Írj emailt!
-                </a>
+                </Link>
             </Box>
         </Box>
     );

--- a/src/components/appHeader.tsx
+++ b/src/components/appHeader.tsx
@@ -1,11 +1,9 @@
-import * as React from "react";
 import { useSelector } from "react-redux";
 import { selectCurrentUser, selectHasPendingWrites } from "../store";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import {
     Button,
     Link,
-    Icon,
     Avatar,
     IconButton,
     Menu,
@@ -15,6 +13,7 @@ import {
     SnackbarContent,
     Box,
 } from "@mui/material";
+import EmailIcon from "@mui/icons-material/Email";
 import CloseIcon from "@mui/icons-material/Close";
 import { CONTACT_HREF } from "../utils";
 import { singInAndReturn, getNavUrl, Page } from "../utils/navUtils";
@@ -38,8 +37,7 @@ export const AppHeader: React.FC = () => {
     const { authSignOut } = useFirebaseAuthService();
 
     // Detect save completion: pending writes just resolved
-    const justSaved = previousHasPendingWrites === true && hasPendingWrites === false;
-    if (justSaved && !isSaveSuccessfulMessageOpen) {
+    if (previousHasPendingWrites === true && hasPendingWrites === false && !isSaveSuccessfulMessageOpen) {
         setIsSaveSuccessfulMessageOpen(true);
     }
 
@@ -55,16 +53,15 @@ export const AppHeader: React.FC = () => {
     const renderContactButton = () => (
         <IconButton
             sx={{
-                width: "36px",
-                height: "36px",
                 fontSize: "16px",
-                color: "black",
+                color: "text.primary",
             }}
             href={CONTACT_HREF}
             disableRipple
             size="large"
+            aria-label="Kapcsolat e-mailben"
         >
-            <Icon>email</Icon>
+            <EmailIcon />
         </IconButton>
     );
 
@@ -72,7 +69,7 @@ export const AppHeader: React.FC = () => {
         const style = {
             width: "30px",
             height: "30px",
-            color: "black",
+            color: "text.primary",
         };
         if (photoUrl) {
             return <Avatar sx={style} src={photoUrl} />;
@@ -96,12 +93,11 @@ export const AppHeader: React.FC = () => {
             <IconButton
                 sx={{
                     marginLeft: "10px",
-                    width: "36px",
-                    height: "36px",
                 }}
                 onClick={(e) => setUserMenuAnchorEl(userMenuAnchorEl ? null : e.currentTarget)}
                 disableRipple
                 size="large"
+                aria-label="Felhasználói menü"
             >
                 {avatar}
             </IconButton>
@@ -109,9 +105,9 @@ export const AppHeader: React.FC = () => {
     };
 
     return (
-        <Box sx={(theme) => ({
+        <Box component="header" sx={(theme) => ({
             height: "60px",
-            color: "black",
+            color: "text.primary",
             backgroundColor: lighten(theme.palette.primary.main, 0.5),
             padding: "10px 20px 10px 20px",
             display: "flex",
@@ -120,7 +116,7 @@ export const AppHeader: React.FC = () => {
             borderColor: theme.palette.divider,
         })}>
             <Box sx={{ fontSize: "18px", flexGrow: 1 }}>
-                <Link component={RouterLink} to={getNavUrl[Page.Home]()} underline="hover" sx={{ color: "black", fontWeight: "bold", fontFamily: "Roboto" }}>
+                <Link component={RouterLink} to={getNavUrl[Page.Home]()} underline="hover" sx={{ color: "text.primary", fontWeight: "bold" }}>
                     Matektábor
                 </Link>
             </Box>
@@ -155,7 +151,7 @@ export const AppHeader: React.FC = () => {
                 open={isSignedOutMessageOpen}
                 action={
                     <IconButton
-                        aria-label="Close"
+                        aria-label="Bezárás"
                         color="inherit"
                         onClick={() => setIsSignedOutMessageOpen(false)}
                         size="large"
@@ -167,7 +163,7 @@ export const AppHeader: React.FC = () => {
             <Snackbar anchorOrigin={{ horizontal: "right", vertical: "top" }} open={hasPendingWrites}>
                 <SnackbarContent
                     message={<span>Mentés... (ha nem vagy online, csatlakozz)</span>}
-                    style={{ backgroundColor: amber[200] }}
+                    style={{ backgroundColor: amber[200], color: "rgba(0,0,0,0.87)" }}
                 />
             </Snackbar>
             <Snackbar
@@ -178,7 +174,7 @@ export const AppHeader: React.FC = () => {
             >
                 <SnackbarContent
                     message={<span>A mentés sikeres volt</span>}
-                    style={{ backgroundColor: green[200] }}
+                    style={{ backgroundColor: green[200], color: "rgba(0,0,0,0.87)" }}
                 />
             </Snackbar>
         </Box>

--- a/src/components/barkochba/barkochbaManageScreen.module.scss
+++ b/src/components/barkochba/barkochbaManageScreen.module.scss
@@ -1,6 +1,7 @@
 .barkochbaManagePanel {
     margin: 40px;
     padding: 20px;
+    max-width: 800px;
 }
 
 .barkochbaManageSubtitle {
@@ -11,4 +12,19 @@ div.barkochbaManageInput {
     margin-right: 20px;
     display: inline-block;
     min-width: 170px;
+}
+
+@media (max-width: 600px) {
+    .barkochbaManagePanel {
+        margin: 16px;
+        padding: 16px;
+    }
+
+    div.barkochbaManageInput {
+        display: block;
+        margin-right: 0;
+        margin-bottom: 12px;
+        min-width: 0;
+        width: 100%;
+    }
 }

--- a/src/components/barkochba/barkochbaScreen.module.scss
+++ b/src/components/barkochba/barkochbaScreen.module.scss
@@ -29,7 +29,8 @@
 }
 
 .barkochbaScreenPanel {
-    max-height: 70vh;
+    flex: 1;
+    min-height: 0;
     overflow: auto;
     padding: 0 20px 20px 20px;
 }

--- a/src/components/barkochba/listeningCampRoomSelector.module.scss
+++ b/src/components/barkochba/listeningCampRoomSelector.module.scss
@@ -12,3 +12,19 @@
     padding-left: 20px;
     width: 50%;
 }
+
+@media (max-width: 600px) {
+    .listeningCampRoomSelector {
+        flex-direction: column;
+    }
+
+    .listeningCampRoomSelectorCamp {
+        width: 100%;
+    }
+
+    .listeningCampRoomSelectorRoom {
+        padding-left: 0;
+        width: 100%;
+        margin-top: 12px;
+    }
+}

--- a/src/components/barkochba/storyBrowser.module.scss
+++ b/src/components/barkochba/storyBrowser.module.scss
@@ -3,8 +3,6 @@ div.itemKnownBy {
 }
 
 div.itemKnownBy0 {
-    border-color: #aeea00;
-    border-color: rgba(0, 0, 0, 0.0);
     border-color: #81d4fa;
     background-color: #e1f5fe;
 }
@@ -26,8 +24,43 @@ div.itemKnownBy3 {
 
 .itemPrimaryLabel {
     display: flex;
+    align-items: center;
 }
 
 .itemLabelTitle {
     flex-grow: 1;
+}
+
+.knownByBadge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 0 5px;
+    margin-left: 8px;
+    flex-shrink: 0;
+}
+
+.knownByBadge0 {
+    background-color: #e1f5fe;
+    color: #0277bd;
+}
+
+.knownByBadge1 {
+    background-color: #fffde7;
+    color: #f57f17;
+}
+
+.knownByBadge2 {
+    background-color: #fff3e0;
+    color: #e65100;
+}
+
+.knownByBadge3 {
+    background-color: #ffebee;
+    color: #c62828;
 }

--- a/src/components/barkochba/storyBrowser.tsx
+++ b/src/components/barkochba/storyBrowser.tsx
@@ -72,6 +72,13 @@ export const StoryBrowser: FC = () => {
             [css.itemKnownBy3]: numberWhoKnow >= 3,
         });
 
+        const knownByBadgeClass = classNames(css.knownByBadge, {
+            [css.knownByBadge0]: numberWhoListening && !numberWhoKnow,
+            [css.knownByBadge1]: numberWhoKnow === 1,
+            [css.knownByBadge2]: numberWhoKnow === 2,
+            [css.knownByBadge3]: numberWhoKnow >= 3,
+        });
+
         return (
             <ListItemButton
                 className={classes}
@@ -86,6 +93,11 @@ export const StoryBrowser: FC = () => {
                             <span className={css.itemLabelTitle}>
                                 {number} - {title}
                             </span>
+                            {numberWhoListening > 0 && (
+                                <span className={knownByBadgeClass} title={`${numberWhoKnow} gyerek ismeri`}>
+                                    {numberWhoKnow}
+                                </span>
+                            )}
                         </div>
                     }
                     secondary={secondaryLabel}
@@ -114,6 +126,7 @@ export const StoryBrowser: FC = () => {
                 <IconButton
                     onClick={handleStarClick(storyId, !isStarredForCurrentUser)}
                     size="large"
+                    aria-label={isStarredForCurrentUser ? "Eltávolítom a kedvencekből" : "Hozzáadom a kedvencekhez"}
                 >
                     {isStarredForCurrentUser ? <StarIcon /> : <StarBorderIcon />}
                 </IconButton>

--- a/src/components/barkochba/storyPanel.tsx
+++ b/src/components/barkochba/storyPanel.tsx
@@ -14,9 +14,10 @@ import {
     Paper,
     Typography,
     Button,
-    Icon,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import DoneIcon from "@mui/icons-material/Done";
+import AddIcon from "@mui/icons-material/Add";
 import { ISelectOption } from "../../commons";
 import { PersonsSelector } from "./personsSelector";
 import css from "./storyPanel.module.scss";
@@ -72,7 +73,7 @@ export const StoryPanel: React.FC = () => {
                         onClick={handleDoneClicked}
                         disabled={currentListeningPersonIds.length === 0}
                     >
-                        <Icon className={css.buttonIcon}>done</Icon>
+                        <DoneIcon className={css.buttonIcon} />
                         Elmeséltem
                     </Button>
                 </p>
@@ -119,7 +120,7 @@ export const StoryPanel: React.FC = () => {
                                 onClick={handleAddClicked}
                                 disabled={personsToAdd.length === 0}
                             >
-                                <Icon className={css.buttonIcon}>add</Icon>
+                                <AddIcon className={css.buttonIcon} />
                                 Hozzáadom
                             </Button>
                         </div>

--- a/src/components/loginProtector.tsx
+++ b/src/components/loginProtector.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from "react";
 import { useSelector } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
 import { AppHeader } from "./appHeader";
 import { AppFooter } from "./appFooter";
-import { Typography } from "@mui/material";
+import { Typography, Button } from "@mui/material";
 import { selectCurrentUser } from "../store";
+import { singInAndReturn } from "../utils/navUtils";
 import css from "./loginProtector.module.scss";
 
 interface ILoginProtectorProps {
@@ -13,6 +15,12 @@ interface ILoginProtectorProps {
 export function LoginProtector({ children }: ILoginProtectorProps) {
     const currentUser = useSelector(selectCurrentUser);
     const isLoggedIn = currentUser !== undefined;
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const handleSignInClick = () => {
+        singInAndReturn(navigate, location.pathname);
+    };
 
     const renderNotLoggedInScreen = () => (
         <div>
@@ -20,6 +28,16 @@ export function LoginProtector({ children }: ILoginProtectorProps) {
             <div className={css.loginProtectorNotLoggedIn}>
                 <Typography variant="h4" align="center" color="textSecondary">
                     A lap használatához be kell jelentkezned.
+                </Typography>
+                <Typography align="center" sx={{ marginTop: 3 }}>
+                    <Button
+                        variant="contained"
+                        color="secondary"
+                        size="large"
+                        onClick={handleSignInClick}
+                    >
+                        Bejelentkezés
+                    </Button>
                 </Typography>
             </div>
             <AppFooter />

--- a/src/components/matektaborApp.module.scss
+++ b/src/components/matektaborApp.module.scss
@@ -11,3 +11,28 @@
     display: flex;
     flex-direction: column;
 }
+
+.skipToContent {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    z-index: 9999;
+
+    &:focus {
+        position: fixed;
+        top: 8px;
+        left: 8px;
+        width: auto;
+        height: auto;
+        padding: 8px 16px;
+        background: #1363A5;
+        color: white;
+        font-size: 14px;
+        text-decoration: none;
+        border-radius: 4px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    }
+}

--- a/src/components/matektaborApp.tsx
+++ b/src/components/matektaborApp.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from "react";
+import { FC, ReactNode } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { AppHeader } from "./appHeader";
 import { AppFooter } from "./appFooter";
@@ -12,107 +12,35 @@ import {
     getNavUrl,
     Page,
 } from "../utils/navUtils";
-import css from "./matektaborApp.module.scss";  
+import css from "./matektaborApp.module.scss";
 import { LoginPanel } from "./auth/LoginPanel";
 import { Helmet, HelmetProvider } from "react-helmet-async";
 import { useDataService } from "../hooks/useDataService";
-import { Container } from "@mui/material";
+import { Box, Container } from "@mui/material";
+
+interface PageLayoutProps {
+    children: ReactNode;
+    title: string;
+    withContainer?: boolean;
+}
+
+function PageLayout({ children, title, withContainer }: PageLayoutProps) {
+    return (
+        <>
+            <Helmet>
+                <title>{title}</title>
+            </Helmet>
+            <AppHeader />
+            <Box component="main" id="main-content" sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+                {withContainer ? <Container sx={{ padding: 5 }}>{children}</Container> : children}
+            </Box>
+            <AppFooter />
+        </>
+    );
+}
 
 export const MatektaborApp: FC = () => {
     useDataService(); // this is included to trigger fetching all the data
-
-    const renderHome = useCallback(() => {
-        // The home screen for now just redirects directly to the barkochba page
-        return <Navigate to={getNavUrl[Page.Barkochba]()} replace />;
-        // Uncomment if you want to render the BarkochbaScreen directly
-        // return (
-        //     <DocumentTitle title={getNavUrlSimpleTitle[Page.Home]}>
-        //         <BarkochbaScreen />
-        //     </DocumentTitle>
-        // );
-    }, []);
-
-    const renderTermsOfService = useCallback(() => (
-        <div>
-            <Helmet>
-                <title>{getNavUrlSimpleTitle[Page.TermsOfService]}</title>
-            </Helmet>
-            <AppHeader />
-            <StaticContent type="terms of service" />
-            <AppFooter />
-        </div>
-    ), []);
-
-    const renderPrivacyPolicy = useCallback(() => (
-        <div>
-            <Helmet>
-                <title>{getNavUrlSimpleTitle[Page.PrivacyPolicy]}</title>
-            </Helmet>
-            <AppHeader />
-            <StaticContent type="privacy policy" />
-            <AppFooter />
-        </div>
-    ), []);
-
-    const renderRouteAuth = useCallback(() => {
-        return (
-            <div>
-                <Helmet>
-                    <title>{getNavUrlSimpleTitle[Page.SignIn]}</title>
-                </Helmet>
-                <AppHeader />
-                <Container sx={{ padding: 5 }}>
-                    <LoginPanel />
-                </Container>
-                <AppFooter />
-            </div>
-        );
-    }, []);
-
-    const renderBarkochba = useCallback(() => (
-        <>
-            <Helmet>
-                <title>{getNavUrlSimpleTitle[Page.Barkochba]}</title>
-            </Helmet>
-            <LoginProtector>
-                <div className={css.barkochbaRouteContainer}>
-                    <AppHeader />
-                    <BarkochbaScreen />
-                    <AppFooter />
-                </div>
-            </LoginProtector>
-        </>
-    ), []);
-
-    const renderBarkochbaExport = useCallback(() => {
-        return (
-            <>
-                <Helmet>
-                    <title>{getNavUrlSimpleTitle[Page.BarkochbaExport]}</title>
-                </Helmet>
-                <LoginProtector>
-                    <BarkochbaExportScreen />
-                </LoginProtector>
-            </>
-        );
-    }, []);
-
-    const renderBarkochbaManage = useCallback(() => (
-        <>
-            <Helmet>
-                <title>{getNavUrlSimpleTitle[Page.BarkochbaManage]}</title>
-            </Helmet>
-            <LoginProtector>
-                <div>
-                    <AppHeader />
-                    <BarkochbaManageScreen />
-                    <AppFooter />
-                </div>
-            </LoginProtector>
-        </>
-    ), []);
-
-    const renderRedirectToHome = useCallback(() => <Navigate to={getNavUrl[Page.Home]()} replace />, []);
 
     return (
         <ScrollToTop>
@@ -120,17 +48,88 @@ export const MatektaborApp: FC = () => {
                 <Helmet>
                     <title>{getNavUrlSimpleTitle[Page.Home]}</title>
                 </Helmet>
+                <a href="#main-content" className={css.skipToContent}>
+                    Ugrás a tartalomhoz
+                </a>
                 <div className={css.matektaborApp}>
                     <div className={css.appContent}>
                         <Routes>
-                            <Route path={getNavUrlTemplate[Page.Home]} element={renderHome()} />
-                            <Route path={getNavUrlTemplate[Page.SignIn]} element={renderRouteAuth()} />
-                            <Route path={getNavUrlTemplate[Page.Barkochba]} element={renderBarkochba()} />
-                            <Route path={getNavUrlTemplate[Page.BarkochbaExport]} element={renderBarkochbaExport()} />
-                            <Route path={getNavUrlTemplate[Page.BarkochbaManage]} element={renderBarkochbaManage()} />
-                            <Route path={getNavUrlTemplate[Page.TermsOfService]} element={renderTermsOfService()} />
-                            <Route path={getNavUrlTemplate[Page.PrivacyPolicy]} element={renderPrivacyPolicy()} />
-                            <Route path="*" element={renderRedirectToHome()} />
+                            <Route
+                                path={getNavUrlTemplate[Page.Home]}
+                                element={<Navigate to={getNavUrl[Page.Barkochba]()} replace />}
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.SignIn]}
+                                element={
+                                    <PageLayout title={getNavUrlSimpleTitle[Page.SignIn]} withContainer>
+                                        <LoginPanel />
+                                    </PageLayout>
+                                }
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.Barkochba]}
+                                element={
+                                    <>
+                                        <Helmet>
+                                            <title>{getNavUrlSimpleTitle[Page.Barkochba]}</title>
+                                        </Helmet>
+                                        <LoginProtector>
+                                            <div className={css.barkochbaRouteContainer}>
+                                                <AppHeader />
+                                                <Box component="main" id="main-content" sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+                                                    <BarkochbaScreen />
+                                                </Box>
+                                                <AppFooter />
+                                            </div>
+                                        </LoginProtector>
+                                    </>
+                                }
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.BarkochbaExport]}
+                                element={
+                                    <>
+                                        <Helmet>
+                                            <title>{getNavUrlSimpleTitle[Page.BarkochbaExport]}</title>
+                                        </Helmet>
+                                        <LoginProtector>
+                                            <BarkochbaExportScreen />
+                                        </LoginProtector>
+                                    </>
+                                }
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.BarkochbaManage]}
+                                element={
+                                    <>
+                                        <Helmet>
+                                            <title>{getNavUrlSimpleTitle[Page.BarkochbaManage]}</title>
+                                        </Helmet>
+                                        <LoginProtector>
+                                            <PageLayout title={getNavUrlSimpleTitle[Page.BarkochbaManage]}>
+                                                <BarkochbaManageScreen />
+                                            </PageLayout>
+                                        </LoginProtector>
+                                    </>
+                                }
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.TermsOfService]}
+                                element={
+                                    <PageLayout title={getNavUrlSimpleTitle[Page.TermsOfService]}>
+                                        <StaticContent type="terms of service" />
+                                    </PageLayout>
+                                }
+                            />
+                            <Route
+                                path={getNavUrlTemplate[Page.PrivacyPolicy]}
+                                element={
+                                    <PageLayout title={getNavUrlSimpleTitle[Page.PrivacyPolicy]}>
+                                        <StaticContent type="privacy policy" />
+                                    </PageLayout>
+                                }
+                            />
+                            <Route path="*" element={<Navigate to={getNavUrl[Page.Home]()} replace />} />
                         </Routes>
                     </div>
                 </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -17,12 +17,4 @@ body {
 
 a, a:hover, a:active, a:visited {
     text-decoration: none !important;
-
-    &.inherit-color {
-        color: inherit;
-    }
-}
-
-a.underline:hover, a.underline:active {
-    text-decoration: underline;
 }

--- a/src/utils/miscUtils.ts
+++ b/src/utils/miscUtils.ts
@@ -1,1 +1,1 @@
-export const CONTACT_HREF = "mailto:ago-taborvezetok[AT]googlegroups[DOT]com?subject=Matektábor app";
+export const CONTACT_HREF = "mailto:ago-taborvezetok@googlegroups.com?subject=Matekt%C3%A1bor%20app";

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -13,7 +13,22 @@ export const LIGHT_THEME = createTheme({
     typography: {
         fontFamily: [
             "Roboto",
-            "Times New Roman",
+            "-apple-system",
+            "BlinkMacSystemFont",
+            "\"Segoe UI\"",
+            "\"Helvetica Neue\"",
+            "Arial",
+            "sans-serif",
         ].join(","),
-    }
+    },
+    components: {
+        MuiIconButton: {
+            styleOverrides: {
+                root: {
+                    minWidth: 44,
+                    minHeight: 44,
+                },
+            },
+        },
+    },
 });


### PR DESCRIPTION
## Summary

Comprehensive UI improvements across accessibility, responsiveness, and code consistency:

- **Accessibility**: Added semantic HTML landmarks (`<header>`, `<footer>`, `<main>`), skip-to-content link, aria-labels on icon buttons, numeric badge alongside color-coded story indicators for colorblind users, 44px minimum touch targets, explicit snackbar text colors for contrast
- **UX fix**: Added sign-in button to login protector screen (previously a dead end with no way to sign in)
- **Responsive design**: Camp/room selector stacks vertically on mobile, manage screen has responsive margins and max-width constraint, story panel uses flex layout instead of fixed `max-height: 70vh`
- **Consistency**: Replaced hardcoded `"black"` with `"text.primary"` theme token, replaced font-based `<Icon>` with SVG imports (`EmailIcon`, `DoneIcon`, `AddIcon`), replaced raw `<a>` tag with MUI `<Link>`, fixed font fallback stack (sans-serif instead of Times New Roman), fixed broken mailto link (`[AT]`/`[DOT]` obfuscation)
- **Code quality**: Created shared `PageLayout` component, removed unused global CSS utility classes, cleaned up dead CSS, simplified route definitions in `matektaborApp.tsx`

**Not changed**: Export screen (intentional legacy styling), placeholder legal text in staticContent.tsx

## Test plan

- [ ] Verify login protector shows sign-in button when not logged in
- [ ] Verify header and footer render correctly with semantic landmarks
- [ ] Verify skip-to-content link appears on Tab key press
- [ ] Verify email contact button opens correct mailto link
- [ ] Verify story browser shows numeric badge when listeners are selected
- [ ] Verify camp/room selector stacks vertically on narrow screens
- [ ] Verify manage screen forms don't stretch on wide screens
- [ ] Verify all routes render correctly (barkochba, manage, terms, privacy, sign-in)
- [ ] Verify export screen is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)