### PR TITLE
Redesign app UI with warm palette and mobile-first layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,45 @@ Node 18 required (see .nvmrc). Uses Yarn as package manager.
 - Unused variables prefixed with `_` are allowed
 - ESLint flat config in `eslint.config.js`
 
+## Local Testing with Firebase Emulator
+
+When testing in a headless browser (e.g. Claude Preview), the Google sign-in popup will be blocked. To sign in programmatically against the Firebase Auth emulator:
+
+1. Make sure the app is loaded from `localhost` (not `127.0.0.1`) so emulator connections work.
+2. The seed data includes two test users (see `seed-data/auth_export/accounts.json`):
+   - **Test User** (`test.user@email.com`, uid: `tZ9LlYdP4tvP3sbE4Hj3lsDNglrc`) — has viewer role
+   - **No Access** (`no.access@email.com`, uid: `0Zo5giDXGAW8q4w2nKHGcjOM3hYG`) — no access
+3. Sign in via the browser console using a fake Google credential (emulator accepts JSON as id_token):
+
+```js
+(async () => {
+  const authModule = await import('/node_modules/.vite/deps/chunk-NF6UUSPI.js?v=325639f1');
+  const auth = authModule.getAuth();
+  await authModule.signOut(auth);
+  const fakeIdToken = JSON.stringify({
+    sub: 'tZ9LlYdP4tvP3sbE4Hj3lsDNglrc',
+    email: 'test.user@email.com',
+    email_verified: true,
+    name: 'Test User'
+  });
+  await fetch('http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      postBody: 'id_token=' + encodeURIComponent(fakeIdToken) + '&providerId=google.com',
+      requestUri: 'http://localhost',
+      returnIdpCredential: true,
+      returnSecureToken: true
+    })
+  });
+  const credential = authModule.GoogleAuthProvider.credential(fakeIdToken);
+  const result = await authModule.signInWithCredential(auth, credential);
+  console.log('Signed in as:', result.user.email, 'uid:', result.user.uid);
+})();
+```
+
+> **Note:** The Vite chunk filename (`chunk-NF6UUSPI.js?v=325639f1`) may change after dependency updates. If the import fails, find the correct chunk by searching for `signInWithEmailAndPassword` in the browser's network/sources tab.
+
 ## Deployment
 
 - Web app auto-deploys via GitHub Actions on merge to `main`

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from "react";
-import { Box, Typography, Button } from "@mui/material";
+import { Box, Typography, Button, Paper } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 
 interface Props {
     children: ReactNode;
@@ -33,22 +34,37 @@ export class ErrorBoundary extends Component<Props, State> {
             return (
                 <Box sx={{
                     display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
                     justifyContent: "center",
+                    alignItems: "center",
                     minHeight: "50vh",
-                    padding: 4,
-                    gap: 2,
+                    padding: { xs: 2, sm: 4 },
                 }}>
-                    <Typography variant="h5" color="error">
-                        Hoppá! Valami hiba történt.
-                    </Typography>
-                    <Typography variant="body1" color="textSecondary">
-                        {this.state.error?.message}
-                    </Typography>
-                    <Button variant="contained" onClick={this.handleReload}>
-                        Oldal újratöltése
-                    </Button>
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            gap: 2,
+                            padding: { xs: "32px 24px", sm: "40px" },
+                            maxWidth: 400,
+                            width: "100%",
+                            borderRadius: 4,
+                            border: "1px solid",
+                            borderColor: "divider",
+                        }}
+                    >
+                        <ErrorOutlineIcon sx={{ fontSize: 48, color: "error.main" }} />
+                        <Typography variant="h5" color="error" align="center">
+                            Hoppá! Valami hiba történt.
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary" align="center">
+                            {this.state.error?.message}
+                        </Typography>
+                        <Button variant="contained" color="secondary" onClick={this.handleReload} fullWidth>
+                            Oldal újratöltése
+                        </Button>
+                    </Paper>
                 </Box>
             );
         }

--- a/src/components/FirebaseComponents.tsx
+++ b/src/components/FirebaseComponents.tsx
@@ -1,5 +1,5 @@
 import { connectAuthEmulator, getAuth } from "firebase/auth";
-import { connectFirestoreEmulator, initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from "firebase/firestore";
+import { connectFirestoreEmulator, getFirestore, initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from "firebase/firestore";
 import { connectFunctionsEmulator, getFunctions } from "firebase/functions";
 import { connectStorageEmulator, getStorage } from "firebase/storage";
 import {
@@ -54,10 +54,15 @@ export function FirebaseComponents(props: { children: React.ReactNode }) {
     auth.languageCode = "hu";
     const functions = getFunctions(app, "europe-west1");
     const { status: firestoreInitStatus, data: firestore } = useInitFirestore(async (firebaseApp) => {
-        const tabManager = persistentMultipleTabManager();
-        const localCache = persistentLocalCache({ tabManager });
-        const db = initializeFirestore(firebaseApp, { localCache });
-        return db;
+        try {
+            const tabManager = persistentMultipleTabManager();
+            const localCache = persistentLocalCache({ tabManager });
+            const db = initializeFirestore(firebaseApp, { localCache });
+            return db;
+        } catch (_e) {
+            // initializeFirestore may have already been called (e.g. during HMR)
+            return getFirestore(firebaseApp);
+        }
     });
     if (firestoreInitStatus === "loading") {
         // TODO(mdanka): add a proper spinner or such here

--- a/src/components/FirebaseComponents.tsx
+++ b/src/components/FirebaseComponents.tsx
@@ -59,8 +59,9 @@ export function FirebaseComponents(props: { children: React.ReactNode }) {
             const localCache = persistentLocalCache({ tabManager });
             const db = initializeFirestore(firebaseApp, { localCache });
             return db;
-        } catch (_e) {
+        } catch (e) {
             // initializeFirestore may have already been called (e.g. during HMR)
+            console.warn("initializeFirestore failed, falling back to getFirestore:", e);
             return getFirestore(firebaseApp);
         }
     });

--- a/src/components/appFooter.tsx
+++ b/src/components/appFooter.tsx
@@ -1,21 +1,22 @@
 import { Box } from "@mui/material";
+import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
 import { CONTACT_HREF } from "../utils";
-import { lighten } from "@mui/material/styles";
 
 export function AppFooter() {
     return (
-        <Box sx={(theme) => ({
-            height: "80px",
-            color: "black",
-            backgroundColor: lighten(theme.palette.primary.main, 0.5),
-            padding: "10px 20px 10px 20px",
+        <Box sx={{
+            height: "56px",
+            color: "text.secondary",
+            backgroundColor: "#F5F5F0",
+            padding: "10px 20px",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
             borderTop: "1px solid",
-            borderColor: theme.palette.divider,
-        })}>
-            <Box sx={{ display: "inline-block", fontFamily: "Roboto" }}>
+            borderColor: "divider",
+        }}>
+            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, fontSize: "14px", fontWeight: 500, fontFamily: "Inter, system-ui, sans-serif" }}>
+                <EmailOutlinedIcon sx={{ fontSize: 16 }} />
                 <a className="underline inherit-color" href={CONTACT_HREF}>
                     Kérdésed van? Írj emailt!
                 </a>

--- a/src/components/appHeader.tsx
+++ b/src/components/appHeader.tsx
@@ -5,7 +5,6 @@ import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import {
     Button,
     Link,
-    Icon,
     Avatar,
     IconButton,
     Menu,
@@ -16,14 +15,12 @@ import {
     Box,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
 import { CONTACT_HREF } from "../utils";
 import { singInAndReturn, getNavUrl, Page } from "../utils/navUtils";
-import { amber } from "@mui/material/colors";
-import { green } from "@mui/material/colors";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useFirebaseAuthService } from "../hooks/useFirebaseAuthService";
 import { usePrevious } from "../hooks/usePrevious";
-import { lighten } from "@mui/material/styles";
 
 export const AppHeader: React.FC = () => {
     const [userMenuAnchorEl, setUserMenuAnchorEl] = useState<HTMLElement | null>(null);
@@ -36,12 +33,17 @@ export const AppHeader: React.FC = () => {
     const hasPendingWrites = useSelector(selectHasPendingWrites);
     const previousHasPendingWrites = usePrevious(hasPendingWrites);
     const { authSignOut } = useFirebaseAuthService();
+    const saveNotifiedRef = useRef(false);
 
     // Detect save completion: pending writes just resolved
-    const justSaved = previousHasPendingWrites === true && hasPendingWrites === false;
-    if (justSaved && !isSaveSuccessfulMessageOpen) {
-        setIsSaveSuccessfulMessageOpen(true);
-    }
+    useEffect(() => {
+        if (hasPendingWrites) {
+            saveNotifiedRef.current = false;
+        } else if (previousHasPendingWrites === true && !saveNotifiedRef.current) {
+            saveNotifiedRef.current = true;
+            setIsSaveSuccessfulMessageOpen(true);
+        }
+    }, [hasPendingWrites, previousHasPendingWrites]);
 
     const handleSignOutClick = async () => {
         await authSignOut();
@@ -55,24 +57,25 @@ export const AppHeader: React.FC = () => {
     const renderContactButton = () => (
         <IconButton
             sx={{
-                width: "36px",
-                height: "36px",
-                fontSize: "16px",
-                color: "black",
+                color: "text.secondary",
+                "&:hover": {
+                    color: "text.primary",
+                    backgroundColor: "rgba(0,0,0,0.04)",
+                },
             }}
             href={CONTACT_HREF}
             disableRipple
             size="large"
         >
-            <Icon>email</Icon>
+            <EmailOutlinedIcon fontSize="small" />
         </IconButton>
     );
 
     const renderAvatar = (photoUrl: string | undefined, displayName?: string) => {
         const style = {
-            width: "30px",
-            height: "30px",
-            color: "black",
+            width: 32,
+            height: 32,
+            fontSize: 14,
         };
         if (photoUrl) {
             return <Avatar sx={style} src={photoUrl} />;
@@ -95,9 +98,12 @@ export const AppHeader: React.FC = () => {
         return (
             <IconButton
                 sx={{
-                    marginLeft: "10px",
-                    width: "36px",
-                    height: "36px",
+                    marginLeft: "8px",
+                    "&:hover": {
+                        outline: "2px solid",
+                        outlineColor: "secondary.light",
+                        outlineOffset: 1,
+                    },
                 }}
                 onClick={(e) => setUserMenuAnchorEl(userMenuAnchorEl ? null : e.currentTarget)}
                 disableRipple
@@ -110,17 +116,29 @@ export const AppHeader: React.FC = () => {
 
     return (
         <Box sx={(theme) => ({
-            height: "60px",
-            color: "black",
-            backgroundColor: lighten(theme.palette.primary.main, 0.5),
-            padding: "10px 20px 10px 20px",
+            height: { xs: "56px", sm: "64px" },
+            color: "text.primary",
+            background: "linear-gradient(135deg, rgba(255,248,231,0.95) 0%, rgba(255,243,214,0.95) 100%)",
+            backdropFilter: "blur(8px)",
+            padding: { xs: "8px 12px", sm: "10px 20px" },
             display: "flex",
             alignItems: "center",
-            borderBottom: "1px solid",
-            borderColor: theme.palette.divider,
+            boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
+            position: "sticky",
+            top: 0,
+            zIndex: theme.zIndex.appBar,
         })}>
-            <Box sx={{ fontSize: "18px", flexGrow: 1 }}>
-                <Link component={RouterLink} to={getNavUrl[Page.Home]()} underline="hover" sx={{ color: "black", fontWeight: "bold", fontFamily: "Roboto" }}>
+            <Box sx={{ fontSize: { xs: "18px", sm: "20px" }, flexGrow: 1 }}>
+                <Link
+                    component={RouterLink}
+                    to={getNavUrl[Page.Home]()}
+                    underline="hover"
+                    sx={{
+                        color: "text.primary",
+                        fontWeight: 700,
+                        fontFamily: "Inter, system-ui, sans-serif",
+                    }}
+                >
                     Matektábor
                 </Link>
             </Box>
@@ -164,23 +182,30 @@ export const AppHeader: React.FC = () => {
                     </IconButton>
                 }
             />
-            <Snackbar anchorOrigin={{ horizontal: "right", vertical: "top" }} open={hasPendingWrites}>
+            <Snackbar anchorOrigin={{ horizontal: "center", vertical: "bottom" }} open={hasPendingWrites}>
                 <SnackbarContent
                     message={<span>Mentés... (ha nem vagy online, csatlakozz)</span>}
-                    style={{ backgroundColor: amber[200] }}
+                    sx={{ backgroundColor: "primary.main", color: "text.primary" }}
                 />
             </Snackbar>
             <Snackbar
                 autoHideDuration={3000}
-                anchorOrigin={{ horizontal: "right", vertical: "top" }}
+                anchorOrigin={{ horizontal: "center", vertical: "bottom" }}
                 open={isSaveSuccessfulMessageOpen}
                 onClose={() => setIsSaveSuccessfulMessageOpen(false)}
-            >
-                <SnackbarContent
-                    message={<span>A mentés sikeres volt</span>}
-                    style={{ backgroundColor: green[200] }}
-                />
-            </Snackbar>
+                message="A mentés sikeres volt"
+                ContentProps={{ sx: { backgroundColor: "success.main", color: "white" } }}
+                action={
+                    <IconButton
+                        aria-label="Close"
+                        color="inherit"
+                        onClick={() => setIsSaveSuccessfulMessageOpen(false)}
+                        size="small"
+                    >
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                }
+            />
         </Box>
     );
 };

--- a/src/components/appHeader.tsx
+++ b/src/components/appHeader.tsx
@@ -18,7 +18,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import EmailOutlinedIcon from "@mui/icons-material/EmailOutlined";
 import { CONTACT_HREF } from "../utils";
 import { singInAndReturn, getNavUrl, Page } from "../utils/navUtils";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useFirebaseAuthService } from "../hooks/useFirebaseAuthService";
 import { usePrevious } from "../hooks/usePrevious";
 
@@ -33,17 +33,12 @@ export const AppHeader: React.FC = () => {
     const hasPendingWrites = useSelector(selectHasPendingWrites);
     const previousHasPendingWrites = usePrevious(hasPendingWrites);
     const { authSignOut } = useFirebaseAuthService();
-    const saveNotifiedRef = useRef(false);
 
     // Detect save completion: pending writes just resolved
-    useEffect(() => {
-        if (hasPendingWrites) {
-            saveNotifiedRef.current = false;
-        } else if (previousHasPendingWrites === true && !saveNotifiedRef.current) {
-            saveNotifiedRef.current = true;
-            setIsSaveSuccessfulMessageOpen(true);
-        }
-    }, [hasPendingWrites, previousHasPendingWrites]);
+    const justSaved = previousHasPendingWrites === true && hasPendingWrites === false;
+    if (justSaved && !isSaveSuccessfulMessageOpen) {
+        setIsSaveSuccessfulMessageOpen(true);
+    }
 
     const handleSignOutClick = async () => {
         await authSignOut();

--- a/src/components/auth/LoginPanel.tsx
+++ b/src/components/auth/LoginPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Paper, Typography } from "@mui/material";
 import { useCallback, useState } from "react";
 import { useAuth, useSigninCheck } from "reactfire";
 import { signInWithPopup, GoogleAuthProvider } from "firebase/auth";
@@ -8,6 +8,7 @@ import { LoginWithEmailLink } from "./LoginWithEmailLink";
 import { useNavigate } from "react-router";
 import { getNavUrl, Page } from "../../utils/navUtils";
 import { useSearchParams } from "react-router-dom";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 
 const IS_EMAIL_LINK_SIGN_IN_ENABLED = false;
 
@@ -56,69 +57,91 @@ export function LoginPanel() {
                 flexDirection: "column",
                 justifyContent: "center",
                 alignItems: "center",
-                height: 1,
+                minHeight: "calc(100vh - 120px)",
+                padding: { xs: "24px 16px", sm: "40px" },
             }}
         >
-            {isLoggingIn && (
-                <CircularProgress size={60} />
-            )}
-            {!isLoggingIn && (
-                <>
-                    {signInCheckStatus === "loading" && <CircularProgress size={60} />}
-                    {signInCheckStatus === "success" && signInCheckResult.signedIn && (
-                        <>
-                            <Typography variant="body1" paragraph>
-                                Már be vagy jelentkezve.
-                            </Typography>
-                            <Button onClick={handleGoToHome} variant="contained">
-                                Tovább a kezdőlapra
-                            </Button>
-                        </>
-                    )}
-                    {signInCheckStatus === "success" && !signInCheckResult.signedIn && (
-                        <>
-                            {activatedFlow === undefined && (
-                                <>
-                                    <Typography variant="h4" paragraph>
-                                        Üdvözlünk!
-                                    </Typography>
-                                    <Typography variant="body1" paragraph>
-
-                                        Kattints alább a bejelentkezéshez!
-                                    </Typography>
-                                </>
-                            )}
-                            <Grid2
-                                container
-                                direction="column"
-                                spacing={2}
-                                alignItems="stretch"
-                                sx={{ padding: "2vh 0" }}
-                            >
+            <Paper
+                elevation={0}
+                sx={{
+                    maxWidth: 400,
+                    width: "100%",
+                    padding: { xs: "32px 24px", sm: "40px" },
+                    borderRadius: 4,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                }}
+            >
+                {isLoggingIn && (
+                    <CircularProgress size={60} />
+                )}
+                {!isLoggingIn && (
+                    <>
+                        {signInCheckStatus === "loading" && <CircularProgress size={60} />}
+                        {signInCheckStatus === "success" && signInCheckResult.signedIn && (
+                            <>
+                                <Typography variant="body1" paragraph>
+                                    Már be vagy jelentkezve.
+                                </Typography>
+                                <Button onClick={handleGoToHome} variant="contained" color="secondary" fullWidth>
+                                    Tovább a kezdőlapra
+                                </Button>
+                            </>
+                        )}
+                        {signInCheckStatus === "success" && !signInCheckResult.signedIn && (
+                            <>
                                 {activatedFlow === undefined && (
-                                    <Grid2>
-                                        <Button onClick={handleInitGoogleLogin} variant="contained" fullWidth>
-                                            Bejelentkezés Google fiókkal
-                                        </Button>
-                                    </Grid2>
+                                    <>
+                                        <AutoAwesomeIcon sx={{ fontSize: 64, color: "primary.main", mb: 2 }} />
+                                        <Typography variant="h4" paragraph sx={{ textAlign: "center" }}>
+                                            Üdvözlünk!
+                                        </Typography>
+                                        <Typography variant="body1" paragraph color="text.secondary" sx={{ textAlign: "center" }}>
+                                            Kattints alább a bejelentkezéshez!
+                                        </Typography>
+                                    </>
                                 )}
-                                {IS_EMAIL_LINK_SIGN_IN_ENABLED && (
-                                    <Grid2>
-                                        <LoginWithEmailLink
-                                            authInfo={{
-                                                auth,
-                                                tenantLanguageCode: "hu",
-                                            }}
-                                            onFlowActivated={handleEmailWithLinkFlowActivated}
-                                            onAuthSuccess={handleAuthSuccess}
-                                        />
-                                    </Grid2>
-                                )}
-                            </Grid2>
-                        </>
-                    )}
-                </>
-            )}
+                                <Grid2
+                                    container
+                                    direction="column"
+                                    spacing={2}
+                                    alignItems="stretch"
+                                    sx={{ width: "100%" }}
+                                >
+                                    {activatedFlow === undefined && (
+                                        <Grid2>
+                                            <Button
+                                                onClick={handleInitGoogleLogin}
+                                                variant="contained"
+                                                color="secondary"
+                                                fullWidth
+                                                sx={{ height: 48 }}
+                                            >
+                                                Bejelentkezés Google fiókkal
+                                            </Button>
+                                        </Grid2>
+                                    )}
+                                    {IS_EMAIL_LINK_SIGN_IN_ENABLED && (
+                                        <Grid2>
+                                            <LoginWithEmailLink
+                                                authInfo={{
+                                                    auth,
+                                                    tenantLanguageCode: "hu",
+                                                }}
+                                                onFlowActivated={handleEmailWithLinkFlowActivated}
+                                                onAuthSuccess={handleAuthSuccess}
+                                            />
+                                        </Grid2>
+                                    )}
+                                </Grid2>
+                            </>
+                        )}
+                    </>
+                )}
+            </Paper>
         </Box>
     );
 }

--- a/src/components/barkochba/barkochbaDrawer.tsx
+++ b/src/components/barkochba/barkochbaDrawer.tsx
@@ -7,7 +7,7 @@ import { getNavUrl, Page } from "../../utils/navUtils";
 
 export function BarkochbaDrawer() {
     return (
-        <Box sx={{ display: "flex", flexDirection: "column", maxHeight: "100vh" }}>
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%", backgroundColor: "#FAFAF7", borderRight: "1px solid", borderColor: "divider" }}>
             <Box sx={{ width: 1, flexShrink: 0 }}>
                 <List>
                     <Link

--- a/src/components/barkochba/barkochbaExportScreen.module.scss
+++ b/src/components/barkochba/barkochbaExportScreen.module.scss
@@ -1,5 +1,6 @@
 .barkochbaExport {
     font-family: 'Times New Roman', Times, serif;
+    background-color: #FFFFFF;
 
     .barkochbaExportTitle {
         font-size: 14pt;

--- a/src/components/barkochba/barkochbaExportScreen.tsx
+++ b/src/components/barkochba/barkochbaExportScreen.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { ICamp, IStory } from "../../commons";
 import { IAppState, selectStoriesOrderedByNumber, selectPersons } from "../../store";
 import { selectCamp, selectCampsListOrderedByNameAndNumber } from "../../store/selectors";
-import { Link, List, ListItemButton, ListItemText } from "@mui/material";
+import { Box, Link, List, ListItemButton, ListItemText, Paper, Typography } from "@mui/material";
 import { Link as RouterLink, useParams } from "react-router-dom";
 import { Page, getNavUrl } from "../../utils/navUtils";
 import css from "./barkochbaExportScreen.module.scss";
@@ -77,20 +77,38 @@ export function BarkochbaExportScreen() {
                 color="textPrimary"
                 component={RouterLink}
                 to={getNavUrl[Page.BarkochbaExport](id)}
-                underline="hover"
+                underline="none"
             >
-                <ListItemButton divider={true}>
-                    <ListItemText primary={`${group}/${number}`} />
-                </ListItemButton>
+                <Paper
+                    elevation={0}
+                    sx={{
+                        mb: 1,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        borderRadius: 3,
+                        transition: "box-shadow 0.2s ease, border-color 0.2s ease",
+                        "&:hover": {
+                            boxShadow: 2,
+                            borderColor: "secondary.light",
+                        },
+                    }}
+                >
+                    <ListItemButton sx={{ borderRadius: 3 }}>
+                        <ListItemText primary={`${group}/${number}`} />
+                    </ListItemButton>
+                </Paper>
             </Link>
         );
     }, []);
 
     const renderCampSelector = useCallback(() => {
         return (
-            <List>
-                {camps.map(renderCampItem)}
-            </List>
+            <Box sx={{ padding: { xs: "16px", sm: "32px 24px" }, maxWidth: 600, margin: "0 auto" }}>
+                <Typography variant="h5" sx={{ fontWeight: 700, mb: 2 }}>Válassz tábort</Typography>
+                <List disablePadding>
+                    {camps.map(renderCampItem)}
+                </List>
+            </Box>
         );
     }, [camps, renderCampItem]);
 

--- a/src/components/barkochba/barkochbaManageScreen.module.scss
+++ b/src/components/barkochba/barkochbaManageScreen.module.scss
@@ -1,14 +1,40 @@
+.barkochbaManageContainer {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+@media (min-width: 600px) {
+    .barkochbaManageContainer {
+        padding: 32px 24px;
+        gap: 24px;
+        max-width: 768px;
+        margin: 0 auto;
+    }
+}
+
 .barkochbaManagePanel {
-    margin: 40px;
-    padding: 20px;
+    padding: 20px 16px;
+}
+
+@media (min-width: 600px) {
+    .barkochbaManagePanel {
+        padding: 32px;
+    }
 }
 
 .barkochbaManageSubtitle {
-    padding-top: 40px;
+    padding-top: 24px;
+}
+
+.barkochbaManageFormStack {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
 }
 
 div.barkochbaManageInput {
-    margin-right: 20px;
-    display: inline-block;
-    min-width: 170px;
+    width: 100%;
 }

--- a/src/components/barkochba/barkochbaManageScreen.tsx
+++ b/src/components/barkochba/barkochbaManageScreen.tsx
@@ -134,9 +134,8 @@ export const BarkochbaManageScreen: React.FC = () => {
     };
 
     const renderGroupSelector = (fieldName: keyof IBarkochbaManageState, value: string | null) => (
-        <FormControl variant="standard">
+        <FormControl variant="standard" fullWidth>
             <Autocomplete
-                className={css.barkochbaManageInput}
                 options={allGroupsAsOptions}
                 value={value == null ? null : stringToSelectOption(value)}
                 onChange={getAutoCompleteFieldUpdater(fieldName)}
@@ -160,22 +159,24 @@ export const BarkochbaManageScreen: React.FC = () => {
     const renderPersonAdd = () => {
         const { newPersonName, newPersonGroup } = manageState;
         return (
-            <Paper className={css.barkochbaManagePanel} elevation={2}>
-                <Typography variant="h5">Új gyerek</Typography>
-                <FormControl variant="standard">
-                    <TextField
-                        variant="filled"
-                        value={newPersonName}
-                        onChange={getTextFieldUpdater("newPersonName")}
-                        className={css.barkochbaManageInput}
-                        placeholder="Tóth János"
-                        label="Név"
-                    />
-                </FormControl>
-                {renderGroupSelector("newPersonGroup", newPersonGroup)}
-                <Button variant="contained" color="primary" onClick={handleNewPersonAdd}>
-                    Létrehozás
-                </Button>
+            <Paper className={css.barkochbaManagePanel} elevation={0} sx={{ border: "1px solid", borderColor: "divider", borderRadius: { xs: 3, sm: 4 } }}>
+                <Typography variant="h5" sx={{ fontWeight: 700 }}>Új gyerek</Typography>
+                <div className={css.barkochbaManageFormStack}>
+                    <FormControl variant="standard" fullWidth>
+                        <TextField
+                            variant="filled"
+                            value={newPersonName}
+                            onChange={getTextFieldUpdater("newPersonName")}
+                            placeholder="Tóth János"
+                            label="Név"
+                            fullWidth
+                        />
+                    </FormControl>
+                    {renderGroupSelector("newPersonGroup", newPersonGroup)}
+                    <Button variant="contained" color="secondary" onClick={handleNewPersonAdd} sx={{ alignSelf: { xs: "stretch", sm: "flex-start" } }}>
+                        Létrehozás
+                    </Button>
+                </div>
             </Paper>
         );
     };
@@ -183,25 +184,27 @@ export const BarkochbaManageScreen: React.FC = () => {
     const renderCampAdd = () => {
         const { newCampGroup, newCampNumber } = manageState;
         return (
-            <Paper className={css.barkochbaManagePanel} elevation={2}>
-                <Typography variant="h5">Új tábor</Typography>
-                {renderGroupSelector("newCampGroup", newCampGroup)}
-                <FormControl variant="standard">
-                    <TextField
-                        variant="filled"
-                        value={newCampNumber}
-                        onChange={getTextFieldUpdater("newCampNumber")}
-                        className={css.barkochbaManageInput}
-                        label="Sorszám"
-                        placeholder="3"
-                        type="number"
-                        error={isNewCampNumberError(newCampNumber)}
-                    />
-                    <FormHelperText>Pl. "3", mint a "Beluga/3"-ban</FormHelperText>
-                </FormControl>
-                <Button variant="contained" color="primary" onClick={handleNewCampAdd}>
-                    Létrehozás
-                </Button>
+            <Paper className={css.barkochbaManagePanel} elevation={0} sx={{ border: "1px solid", borderColor: "divider", borderRadius: { xs: 3, sm: 4 } }}>
+                <Typography variant="h5" sx={{ fontWeight: 700 }}>Új tábor</Typography>
+                <div className={css.barkochbaManageFormStack}>
+                    {renderGroupSelector("newCampGroup", newCampGroup)}
+                    <FormControl variant="standard" fullWidth>
+                        <TextField
+                            variant="filled"
+                            value={newCampNumber}
+                            onChange={getTextFieldUpdater("newCampNumber")}
+                            label="Sorszám"
+                            placeholder="3"
+                            type="number"
+                            error={isNewCampNumberError(newCampNumber)}
+                            fullWidth
+                        />
+                        <FormHelperText>Pl. "3", mint a "Beluga/3"-ban</FormHelperText>
+                    </FormControl>
+                    <Button variant="contained" color="secondary" onClick={handleNewCampAdd} sx={{ alignSelf: { xs: "stretch", sm: "flex-start" } }}>
+                        Létrehozás
+                    </Button>
+                </div>
             </Paper>
         );
     };
@@ -211,49 +214,46 @@ export const BarkochbaManageScreen: React.FC = () => {
         const currentCampOption = selectedCamp ? campToSelectOption(selectedCamp) : null;
         const currentRoomOption = roomsSelectionRoomName ? { value: roomsSelectionRoomName, label: roomsSelectionRoomName } : null;
         return (
-            <Paper className={css.barkochbaManagePanel} elevation={2}>
-                <Typography variant="h5">Szobabeosztás</Typography>
+            <Paper className={css.barkochbaManagePanel} elevation={0} sx={{ border: "1px solid", borderColor: "divider", borderRadius: { xs: 3, sm: 4 } }}>
+                <Typography variant="h5" sx={{ fontWeight: 700 }}>Szobabeosztás</Typography>
                 <Typography className={css.barkochbaManageSubtitle} variant="subtitle1">
                     Melyik tábor?
                 </Typography>
-                <div>
-                    <Autocomplete
-                        options={availableCampsAsOptions}
-                        value={currentCampOption}
-                        onChange={handleCampChange}
-                        renderInput={params => (
-                            <TextField {...params} label="Tábor" placeholder="Válassz tábort" variant="filled" />
-                        )}
-                        getOptionLabel={(option: ISelectOption) => option.label}
-                    />
-                </div>
+                <Autocomplete
+                    options={availableCampsAsOptions}
+                    value={currentCampOption}
+                    onChange={handleCampChange}
+                    renderInput={params => (
+                        <TextField {...params} label="Tábor" placeholder="Válassz tábort" variant="filled" />
+                    )}
+                    getOptionLabel={(option: ISelectOption) => option.label}
+                />
                 {currentCampOption && (
                     <div>
                         <Typography className={css.barkochbaManageSubtitle} variant="subtitle1">
                             Melyik szoba?
                         </Typography>
-                        <Typography variant="subtitle2">
+                        <Typography variant="subtitle2" color="text.secondary">
                             Új szoba létrehozásához csak gépeld be a szoba nevét.
                         </Typography>
-                        <div>
-                            <Autocomplete
-                                options={availableRoomsAsOptions}
-                                value={currentRoomOption}
-                                onChange={handleRoomChange}
-                                filterOptions={(options, params) => {
-                                    const filter = createFilterOptions<ISelectOption>();
-                                    const filtered = filter(options, params);
-                                    if (params.inputValue) {
-                                        filtered.push({ value: params.inputValue, label: `Új: "${params.inputValue}"` });
-                                    }
-                                    return filtered;
-                                }}
-                                renderInput={params => (
-                                    <TextField {...params} label="Szoba" placeholder="Válassz szobát" variant="filled" />
-                                )}
-                                getOptionLabel={(option: ISelectOption) => option.label}
-                            />
-                        </div>
+                        <Autocomplete
+                            sx={{ mt: 1 }}
+                            options={availableRoomsAsOptions}
+                            value={currentRoomOption}
+                            onChange={handleRoomChange}
+                            filterOptions={(options, params) => {
+                                const filter = createFilterOptions<ISelectOption>();
+                                const filtered = filter(options, params);
+                                if (params.inputValue) {
+                                    filtered.push({ value: params.inputValue, label: `Új: "${params.inputValue}"` });
+                                }
+                                return filtered;
+                            }}
+                            renderInput={params => (
+                                <TextField {...params} label="Szoba" placeholder="Válassz szobát" variant="filled" />
+                            )}
+                            getOptionLabel={(option: ISelectOption) => option.label}
+                        />
                     </div>
                 )}
                 {currentCampOption && currentRoomOption && (
@@ -261,13 +261,11 @@ export const BarkochbaManageScreen: React.FC = () => {
                         <Typography className={css.barkochbaManageSubtitle} variant="subtitle1">
                             A szoba lakói
                         </Typography>
-                        <div>
-                            <PersonsSelector
-                                allPersons={allPersonsAsOptions}
-                                selectedPersons={roomPeopleAsOptions}
-                                onChange={handleRoomPersonsChange}
-                            />
-                        </div>
+                        <PersonsSelector
+                            allPersons={allPersonsAsOptions}
+                            selectedPersons={roomPeopleAsOptions}
+                            onChange={handleRoomPersonsChange}
+                        />
                     </div>
                 )}
             </Paper>
@@ -275,7 +273,7 @@ export const BarkochbaManageScreen: React.FC = () => {
     };
     
     return (
-        <div>
+        <div className={css.barkochbaManageContainer}>
             {renderPersonAdd()}
             {renderCampAdd()}
             {renderRoomEdit()}

--- a/src/components/barkochba/barkochbaScreen.module.scss
+++ b/src/components/barkochba/barkochbaScreen.module.scss
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: row;
     width: 100%;
+    overflow-x: hidden;
 }
 
 .barkochbaScreenContentArea {
@@ -10,10 +11,19 @@
     flex-direction: column;
     flex-grow: 1;
     max-width: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow-x: hidden;
 }
 
 .barkochbaScreenDrawerToggle {
-    padding: 20px 20px 0 20px;
+    padding: 16px 16px 0 16px;
+}
+
+@media (min-width: 600px) {
+    .barkochbaScreenDrawerToggle {
+        padding: 20px 24px 0 24px;
+    }
 }
 
 .barkochbaScreenDrawerToggleButton {
@@ -25,13 +35,26 @@
 }
 
 .barkochbaScreenPersonSelector {
-    padding: 20px;
+    padding: 16px;
+}
+
+@media (min-width: 600px) {
+    .barkochbaScreenPersonSelector {
+        padding: 24px;
+    }
 }
 
 .barkochbaScreenPanel {
-    max-height: 70vh;
+    flex: 1;
     overflow: auto;
-    padding: 0 20px 20px 20px;
+    min-height: 0;
+    padding: 0 16px 16px 16px;
+}
+
+@media (min-width: 600px) {
+    .barkochbaScreenPanel {
+        padding: 0 24px 24px 24px;
+    }
 }
 
 .personSelectorContent {
@@ -41,6 +64,7 @@
 // DRAWER
 
 .barkochbaScreenMobileDrawerPaper {
-    width: 80vw;
+    width: 85vw;
     height: 100%;
+    overflow: hidden;
 }

--- a/src/components/barkochba/barkochbaScreen.tsx
+++ b/src/components/barkochba/barkochbaScreen.tsx
@@ -6,7 +6,7 @@ import {
     SwipeableDrawer,
     Button,
     Box,
-    CircularProgress,
+    Skeleton,
 } from "@mui/material";
 import { PersonsSelector } from "./personsSelector";
 import { ISelectOption } from "../../commons";
@@ -69,15 +69,21 @@ export function BarkochbaScreen() {
 
     if (hasViewerRole === undefined || !isAllDataLoaded) {
         return (
-            <Box className={css.barkochbaScreen} sx={{ padding: 5, display: "flex", justifyContent: "center" }}>
-                <CircularProgress />
+            <Box className={css.barkochbaScreen} sx={{ padding: { xs: 2, sm: 3 } }}>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2, width: "100%" }}>
+                    <Skeleton variant="rounded" height={56} sx={{ borderRadius: 3 }} />
+                    <Skeleton variant="rounded" height={200} sx={{ borderRadius: 3 }} />
+                    {[1, 2, 3].map(i => (
+                        <Skeleton key={i} variant="rounded" height={48} sx={{ borderRadius: 2 }} />
+                    ))}
+                </Box>
             </Box>
         )
     }
 
     return (
         <div className={css.barkochbaScreen}>
-            <Box component="div" sx={{ display: { xs: "none", sm: "block" } }}>
+            <Box component="div" sx={{ display: { xs: "none", sm: "block" }, width: 320, flexShrink: 0 }}>
                 <BarkochbaDrawer />
             </Box>
             <Box
@@ -107,15 +113,16 @@ export function BarkochbaScreen() {
                 >
                     <Button
                         className={css.barkochbaScreenDrawerToggleButton}
-                        variant="contained"
+                        variant="outlined"
+                        color="secondary"
                         onClick={handleDrawerToggle}
+                        startIcon={<MenuIcon />}
                     >
-                        <MenuIcon className={css.barkochbaScreenDrawerToggleButtonIcon} />
                         Navigáció és barkochbatörténetek
                     </Button>
                 </Box>
                 <div className={css.barkochbaScreenPersonSelector}>
-                    <Accordion elevation={2} defaultExpanded={true}>
+                    <Accordion elevation={0} defaultExpanded={true}>
                         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                             <Typography variant="subtitle1">{personSelectorTitle}</Typography>
                         </AccordionSummary>

--- a/src/components/barkochba/listeningCampRoomSelector.module.scss
+++ b/src/components/barkochba/listeningCampRoomSelector.module.scss
@@ -1,14 +1,33 @@
 .listeningCampRoomSelector {
     display: flex;
-    flex-direction: row;
-    margin-bottom: 20px;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+@media (min-width: 600px) {
+    .listeningCampRoomSelector {
+        flex-direction: row;
+        gap: 16px;
+    }
 }
 
 .listeningCampRoomSelectorCamp {
-    width: 50%;
+    width: 100%;
+}
+
+@media (min-width: 600px) {
+    .listeningCampRoomSelectorCamp {
+        width: 50%;
+    }
 }
 
 .listeningCampRoomSelectorRoom {
-    padding-left: 20px;
-    width: 50%;
+    width: 100%;
+}
+
+@media (min-width: 600px) {
+    .listeningCampRoomSelectorRoom {
+        width: 50%;
+    }
 }

--- a/src/components/barkochba/storyBrowser.module.scss
+++ b/src/components/barkochba/storyBrowser.module.scss
@@ -1,27 +1,26 @@
 div.itemKnownBy {
-    border-left: 10px solid;
+    border-left: 4px solid;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 div.itemKnownBy0 {
-    border-color: #aeea00;
-    border-color: rgba(0, 0, 0, 0.0);
-    border-color: #81d4fa;
-    background-color: #e1f5fe;
+    border-color: #60A5FA;
+    background-color: #EFF6FF;
 }
 
 div.itemKnownBy1 {
-    border-color: #fff176;
-    background-color: #fffde7;
+    border-color: #FBBF24;
+    background-color: #FFFBEB;
 }
 
 div.itemKnownBy2 {
-    border-color: #fb8c00;
-    background-color: #fff3e0;
+    border-color: #F97316;
+    background-color: #FFF7ED;
 }
 
 div.itemKnownBy3 {
-    border-color: #e53935;
-    background-color: #ffebee;
+    border-color: #EF4444;
+    background-color: #FEF2F2;
 }
 
 .itemPrimaryLabel {

--- a/src/components/barkochba/storyBrowser.tsx
+++ b/src/components/barkochba/storyBrowser.tsx
@@ -15,7 +15,6 @@ import {
     ListItemButton,
     Chip,
     Tooltip,
-    Avatar,
     IconButton,
     Divider,
     ListSubheader,
@@ -92,28 +91,29 @@ export const StoryBrowser: FC = () => {
                 />
                 <Tooltip title="Ennyien hallották már" placement="bottom">
                     <Chip
-                        className={css.itemLabelHeardNumber}
-                        avatar={
-                            <Avatar>
-                                <PersonIcon />
-                            </Avatar>
-                        }
+                        size="small"
+                        variant="outlined"
+                        icon={<PersonIcon />}
                         label={personsWhoKnow.length.toString()}
                     />
                 </Tooltip>
                 <Tooltip title="Ennyien kedvelik" placement="bottom">
                     <Chip
-                        avatar={
-                            <Avatar>
-                                <StarRateIcon />
-                            </Avatar>
-                        }
+                        size="small"
+                        variant="outlined"
+                        icon={<StarRateIcon />}
                         label={numberWhoStarred.toString()}
+                        sx={{ ml: 0.5 }}
                     />
                 </Tooltip>
                 <IconButton
                     onClick={handleStarClick(storyId, !isStarredForCurrentUser)}
                     size="large"
+                    sx={{
+                        transition: "transform 0.15s ease",
+                        "&:active": { transform: "scale(0.9)" },
+                        color: isStarredForCurrentUser ? "primary.main" : "text.secondary",
+                    }}
                 >
                     {isStarredForCurrentUser ? <StarIcon /> : <StarBorderIcon />}
                 </IconButton>
@@ -123,20 +123,20 @@ export const StoryBrowser: FC = () => {
 
     return (
         <div className={css.storyBrowser}>
-            <List subheader={<ListSubheader disableSticky>Rendezés</ListSubheader>}>
+            <List subheader={<ListSubheader disableSticky sx={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "text.secondary" }}>Rendezés</ListSubheader>}>
                 <ListItem>
                     <BarkochbaSortingSelector />
                 </ListItem>
             </List>
             {starredStories.length > 0 && (
                 <div>
-                    <List subheader={<ListSubheader disableSticky>Kedvencek</ListSubheader>}>
+                    <List subheader={<ListSubheader disableSticky sx={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "text.secondary" }}>Kedvencek</ListSubheader>}>
                         {starredStories.map(renderStory)}
                     </List>
                     <Divider />
                 </div>
             )}
-            <List subheader={<ListSubheader disableSticky>Összes barkochbatörténet</ListSubheader>}>
+            <List subheader={<ListSubheader disableSticky sx={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.05em", color: "text.secondary" }}>Összes barkochbatörténet</ListSubheader>}>
                 {stories.map(renderStory)}
             </List>
         </div>

--- a/src/components/barkochba/storyPanel.module.scss
+++ b/src/components/barkochba/storyPanel.module.scss
@@ -1,9 +1,17 @@
-div.peopleWhoKnow {
-    display: block;
+.storyPanel {
+    padding: 16px;
+    border: 1px solid #E5E7EB;
+    border-radius: 12px;
 }
 
-.doneButton {
-    float: right;
+@media (min-width: 600px) {
+    .storyPanel {
+        padding: 24px;
+    }
+}
+
+div.peopleWhoKnow {
+    display: block;
 }
 
 .buttonIcon {
@@ -12,18 +20,50 @@ div.peopleWhoKnow {
 }
 
 .emptyState {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 40vh;
+    gap: 16px;
     padding: 20px;
+}
+
+.emptyStateIcon {
+    font-size: 80px;
+    color: rgba(0, 0, 0, 0.15);
+}
+
+.storyDescription {
+    padding: 16px;
+    background-color: #FAFAF7;
+    border-radius: 12px;
+    margin-bottom: 16px;
+}
+
+.storyTitleRow {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 8px;
 }
 
 .peopleWhoKnowAdd {
     display: flex;
-    flex-direction: row;
-    margin-bottom: 20px
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+@media (min-width: 600px) {
+    .peopleWhoKnowAdd {
+        flex-direction: row;
+    }
 }
 
 .peopleWhoKnowAddSelector {
     flex-grow: 1;
-    margin-right: 20px;
 }
 
 .peopleWhoKnowAddButton {

--- a/src/components/barkochba/storyPanel.tsx
+++ b/src/components/barkochba/storyPanel.tsx
@@ -14,9 +14,13 @@ import {
     Paper,
     Typography,
     Button,
-    Icon,
+    Box,
+    Divider,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import AddIcon from "@mui/icons-material/Add";
+import MenuBookOutlinedIcon from "@mui/icons-material/MenuBookOutlined";
 import { ISelectOption } from "../../commons";
 import { PersonsSelector } from "./personsSelector";
 import css from "./storyPanel.module.scss";
@@ -64,86 +68,92 @@ export const StoryPanel: React.FC = () => {
 
         return (
             <div>
-                <p>
+                <div className={css.storyTitleRow}>
+                    <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                        {number} - {title}
+                    </Typography>
                     <Button
-                        className={css.doneButton}
                         variant="contained"
-                        color="primary"
+                        color="secondary"
                         onClick={handleDoneClicked}
                         disabled={currentListeningPersonIds.length === 0}
+                        startIcon={<CheckCircleOutlineIcon />}
+                        sx={{ flexShrink: 0 }}
                     >
-                        <Icon className={css.buttonIcon}>done</Icon>
                         Elmeséltem
                     </Button>
-                </p>
-                <Typography variant="h5" paragraph>
-                    {number} - {title}
-                </Typography>
-                <Typography variant="body2" paragraph>
-                    {description}
-                </Typography>
-                <Accordion elevation={2}>
-                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography variant="subtitle1">Megoldás</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                        <Typography variant="body2">{solution}</Typography>
-                    </AccordionDetails>
-                </Accordion>
-                <Accordion elevation={2}>
-                    <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                        <Typography variant="subtitle1">Kik ismerik?</Typography>
-                    </AccordionSummary>
-                    <AccordionDetails className={css.peopleWhoKnow}>
-                        {someoneListeningKnowsIt && (
+                </div>
+                <Divider sx={{ mb: 2 }} />
+                <div className={css.storyDescription}>
+                    <Typography variant="body2">
+                        {description}
+                    </Typography>
+                </div>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                    <Accordion elevation={0}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography variant="subtitle1">Megoldás</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <Typography variant="body2">{solution}</Typography>
+                        </AccordionDetails>
+                    </Accordion>
+                    <Accordion elevation={0}>
+                        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography variant="subtitle1">Kik ismerik?</Typography>
+                        </AccordionSummary>
+                        <AccordionDetails className={css.peopleWhoKnow}>
+                            {someoneListeningKnowsIt && (
+                                <Typography variant="body2" paragraph>
+                                    <b>
+                                        Ő{isPluralListeningAndKnowing ? "k" : ""} ismeri
+                                        {isPluralListeningAndKnowing ? "k" : ""} a mostani hallgatóságból:
+                                    </b>{" "}
+                                    {currentListeningPersonsWhoKnowStoryAsSelectOptions
+                                        .map(option => option.label)
+                                        .join(", ")}
+                                </Typography>
+                            )}
+                            <div className={css.peopleWhoKnowAdd}>
+                                <PersonsSelector
+                                    className={css.peopleWhoKnowAddSelector}
+                                    allPersons={personsAsSelectOptions}
+                                    selectedPersons={personsToAdd}
+                                    onChange={handlePersonsWhoKnowChange}
+                                />
+                                <Button
+                                    className={css.peopleWhoKnowAddButton}
+                                    variant="outlined"
+                                    onClick={handleAddClicked}
+                                    disabled={personsToAdd.length === 0}
+                                    startIcon={<AddIcon />}
+                                >
+                                    Hozzáadom
+                                </Button>
+                            </div>
                             <Typography variant="body2" paragraph>
-                                <b>
-                                    Ő{isPluralListeningAndKnowing ? "k" : ""} ismeri
-                                    {isPluralListeningAndKnowing ? "k" : ""} a mostani hallgatóságból:
-                                </b>{" "}
-                                {currentListeningPersonsWhoKnowStoryAsSelectOptions
-                                    .map(option => option.label)
-                                    .join(", ")}
+                                <b>Mindenki, aki ismeri:</b>{" "}
+                                {personsWhoKnowAsSelectOptions.map(option => option.label).join(", ")}
                             </Typography>
-                        )}
-                        <div className={css.peopleWhoKnowAdd}>
-                            <PersonsSelector
-                                className={css.peopleWhoKnowAddSelector}
-                                allPersons={personsAsSelectOptions}
-                                selectedPersons={personsToAdd}
-                                onChange={handlePersonsWhoKnowChange}
-                            />
-                            <Button
-                                className={css.peopleWhoKnowAddButton}
-                                variant="contained"
-                                onClick={handleAddClicked}
-                                disabled={personsToAdd.length === 0}
-                            >
-                                <Icon className={css.buttonIcon}>add</Icon>
-                                Hozzáadom
-                            </Button>
-                        </div>
-                        <Typography variant="body2" paragraph>
-                            <b>Mindenki, aki ismeri:</b>{" "}
-                            {personsWhoKnowAsSelectOptions.map(option => option.label).join(", ")}
-                        </Typography>
-                    </AccordionDetails>
-                </Accordion>
+                        </AccordionDetails>
+                    </Accordion>
+                </Box>
             </div>
         );
     };
 
     const renderPlaceholder = () => {
         return (
-            <Typography
-                className={css.emptyState}
-                variant="h4"
-                paragraph
-                align="center"
-                color="textSecondary"
-            >
-                Válassz egy barkochbatörténetet!
-            </Typography>
+            <div className={css.emptyState}>
+                <MenuBookOutlinedIcon className={css.emptyStateIcon} />
+                <Typography
+                    variant="h5"
+                    align="center"
+                    color="textSecondary"
+                >
+                    Válassz egy barkochbatörténetet!
+                </Typography>
+            </div>
         );
     };
 

--- a/src/components/loginProtector.tsx
+++ b/src/components/loginProtector.tsx
@@ -2,9 +2,11 @@ import { ReactNode } from "react";
 import { useSelector } from "react-redux";
 import { AppHeader } from "./appHeader";
 import { AppFooter } from "./appFooter";
-import { Typography } from "@mui/material";
+import { Typography, Button, Paper, Box } from "@mui/material";
 import { selectCurrentUser } from "../store";
-import css from "./loginProtector.module.scss";
+import { Link as RouterLink } from "react-router-dom";
+import { getNavUrl, Page } from "../utils/navUtils";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 
 interface ILoginProtectorProps {
     children: ReactNode;
@@ -17,11 +19,44 @@ export function LoginProtector({ children }: ILoginProtectorProps) {
     const renderNotLoggedInScreen = () => (
         <div>
             <AppHeader />
-            <div className={css.loginProtectorNotLoggedIn}>
-                <Typography variant="h4" align="center" color="textSecondary">
-                    A lap használatához be kell jelentkezned.
-                </Typography>
-            </div>
+            <Box sx={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                minHeight: "calc(100vh - 120px)",
+                padding: { xs: "24px 16px", sm: "40px" },
+            }}>
+                <Paper
+                    elevation={0}
+                    sx={{
+                        maxWidth: 400,
+                        width: "100%",
+                        padding: { xs: "32px 24px", sm: "40px" },
+                        borderRadius: 4,
+                        border: "1px solid",
+                        borderColor: "divider",
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        gap: 2,
+                    }}
+                >
+                    <LockOutlinedIcon sx={{ fontSize: 48, color: "text.secondary" }} />
+                    <Typography variant="h5" align="center">
+                        A lap használatához be kell jelentkezned.
+                    </Typography>
+                    <Button
+                        component={RouterLink}
+                        to={getNavUrl[Page.SignIn]()}
+                        variant="contained"
+                        color="secondary"
+                        fullWidth
+                        sx={{ height: 48, mt: 1 }}
+                    >
+                        Bejelentkezés
+                    </Button>
+                </Paper>
+            </Box>
             <AppFooter />
         </div>
     );

--- a/src/components/staticContent.module.scss
+++ b/src/components/staticContent.module.scss
@@ -1,3 +1,11 @@
 .staticContent {
-    padding: 20px 40px;
+    padding: 24px 16px;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+@media (min-width: 600px) {
+    .staticContent {
+        padding: 32px 24px;
+    }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,12 +1,15 @@
 // @import "~normalize.css";
-@import url('https://fonts.googleapis.com/css?family=Roboto:400,700&subset=latin-ext');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&subset=latin-ext&display=swap');
 
 html {
     box-sizing: border-box;
+    scroll-behavior: smooth;
+    overflow-x: hidden;
 }
 
 body {
   margin: 0;
+  background-color: #FAFAF7;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -4,16 +4,177 @@ export const LIGHT_THEME = createTheme({
     palette: {
         mode: "light",
         primary: {
-            main: "#ffc40d",
+            main: "#F5A623",
+            light: "#FFF3D6",
+            dark: "#C77F00",
         },
         secondary: {
-            main: "#1363A5",
+            main: "#2563EB",
+            light: "#DBEAFE",
+            dark: "#1E40AF",
+        },
+        background: {
+            default: "#FAFAF7",
+            paper: "#FFFFFF",
+        },
+        text: {
+            primary: "#1A1A2E",
+            secondary: "#6B7280",
+        },
+        divider: "#E5E7EB",
+        success: {
+            main: "#16A34A",
+        },
+        error: {
+            main: "#DC2626",
         },
     },
     typography: {
-        fontFamily: [
-            "Roboto",
-            "Times New Roman",
-        ].join(","),
-    }
+        fontFamily: ["Inter", "system-ui", "sans-serif"].join(","),
+        h4: {
+            fontWeight: 700,
+        },
+        h5: {
+            fontWeight: 600,
+        },
+        subtitle1: {
+            fontWeight: 600,
+        },
+        subtitle2: {
+            fontWeight: 500,
+        },
+        button: {
+            textTransform: "none" as const,
+            fontWeight: 600,
+        },
+    },
+    shape: {
+        borderRadius: 12,
+    },
+    shadows: [
+        "none",
+        "0 1px 2px rgba(0,0,0,0.04)",
+        "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)",
+        "0 2px 4px rgba(0,0,0,0.05), 0 1px 3px rgba(0,0,0,0.04)",
+        "0 4px 6px rgba(0,0,0,0.05), 0 2px 4px rgba(0,0,0,0.04)",
+        "0 6px 8px rgba(0,0,0,0.05), 0 3px 5px rgba(0,0,0,0.04)",
+        "0 8px 12px rgba(0,0,0,0.05), 0 4px 6px rgba(0,0,0,0.04)",
+        "0 10px 15px rgba(0,0,0,0.05), 0 5px 8px rgba(0,0,0,0.04)",
+        "0 12px 18px rgba(0,0,0,0.06), 0 6px 10px rgba(0,0,0,0.04)",
+        "0 14px 20px rgba(0,0,0,0.06), 0 7px 12px rgba(0,0,0,0.04)",
+        "0 16px 24px rgba(0,0,0,0.06), 0 8px 14px rgba(0,0,0,0.04)",
+        "0 18px 28px rgba(0,0,0,0.06), 0 9px 16px rgba(0,0,0,0.04)",
+        "0 20px 32px rgba(0,0,0,0.06), 0 10px 18px rgba(0,0,0,0.04)",
+        "0 22px 36px rgba(0,0,0,0.07), 0 11px 20px rgba(0,0,0,0.04)",
+        "0 24px 38px rgba(0,0,0,0.07), 0 12px 22px rgba(0,0,0,0.04)",
+        "0 26px 40px rgba(0,0,0,0.07), 0 13px 24px rgba(0,0,0,0.04)",
+        "0 28px 44px rgba(0,0,0,0.07), 0 14px 26px rgba(0,0,0,0.04)",
+        "0 30px 48px rgba(0,0,0,0.08), 0 15px 28px rgba(0,0,0,0.04)",
+        "0 32px 52px rgba(0,0,0,0.08), 0 16px 30px rgba(0,0,0,0.04)",
+        "0 34px 56px rgba(0,0,0,0.08), 0 17px 32px rgba(0,0,0,0.04)",
+        "0 36px 60px rgba(0,0,0,0.09), 0 18px 34px rgba(0,0,0,0.04)",
+        "0 38px 64px rgba(0,0,0,0.09), 0 19px 36px rgba(0,0,0,0.04)",
+        "0 40px 68px rgba(0,0,0,0.09), 0 20px 38px rgba(0,0,0,0.04)",
+        "0 42px 72px rgba(0,0,0,0.10), 0 21px 40px rgba(0,0,0,0.04)",
+        "0 44px 76px rgba(0,0,0,0.10), 0 22px 42px rgba(0,0,0,0.04)",
+    ],
+    components: {
+        MuiButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 10,
+                    padding: "10px 20px",
+                    minHeight: 44,
+                    transition: "all 0.2s ease",
+                },
+            },
+        },
+        MuiPaper: {
+            styleOverrides: {
+                root: {
+                    transition: "box-shadow 0.2s ease",
+                },
+            },
+        },
+        MuiAccordion: {
+            styleOverrides: {
+                root: {
+                    borderRadius: "12px !important",
+                    border: "1px solid #E5E7EB",
+                    "&:before": {
+                        display: "none",
+                    },
+                    "&:first-of-type": {
+                        borderRadius: "12px !important",
+                    },
+                    "&:last-of-type": {
+                        borderRadius: "12px !important",
+                    },
+                },
+            },
+        },
+        MuiAccordionSummary: {
+            styleOverrides: {
+                root: {
+                    fontWeight: 600,
+                    minHeight: 56,
+                },
+            },
+        },
+        MuiChip: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 8,
+                    fontWeight: 500,
+                },
+            },
+        },
+        MuiListItemButton: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 8,
+                    margin: "2px 8px",
+                    minHeight: 48,
+                    transition: "background-color 0.15s ease, border-color 0.15s ease",
+                    "&.Mui-selected": {
+                        backgroundColor: "transparent",
+                        border: "2px solid #2563EB",
+                        "&:hover": {
+                            backgroundColor: "transparent",
+                        },
+                    },
+                },
+            },
+        },
+        MuiSnackbarContent: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 10,
+                },
+            },
+        },
+        MuiMenu: {
+            styleOverrides: {
+                paper: {
+                    borderRadius: 10,
+                },
+            },
+        },
+        MuiMenuItem: {
+            styleOverrides: {
+                root: {
+                    borderRadius: 6,
+                    margin: "2px 6px",
+                },
+            },
+        },
+        MuiIconButton: {
+            styleOverrides: {
+                root: {
+                    minWidth: 44,
+                    minHeight: 44,
+                },
+            },
+        },
+    },
 });

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,1 +1,5 @@
 $darkBackground: #24292e;
+$bg-warm: #FAFAF7;
+$border-light: #E5E7EB;
+$text-primary: #1A1A2E;
+$text-secondary: #6B7280;


### PR DESCRIPTION
## Summary
- Complete visual redesign: warm amber-gold/blue color palette, Inter font, soft shadows, 12px border radius
- Mobile-first responsive layout across all screens (login, header/footer, story browser, story panel, manage, export)
- MUI theme overrides for buttons, papers, accordions, chips, list items, snackbars, menus
- Preserves legacy `/barkochba/export/{id}` table styling unchanged
- Adds Firebase Auth emulator programmatic sign-in docs to CLAUDE.md

## Test plan
- [ ] Verify mobile layout has no horizontal scroll on 375px viewport
- [ ] Check story list selected state shows blue border (not background change)
- [ ] Confirm snackbar auto-dismisses and X button works
- [ ] Verify export table at `/barkochba/export/{id}` retains white background and original styling
- [ ] Test login flow on the redesigned sign-in page
- [ ] Check header/footer render Inter font correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)