### PR TITLE
Skip Firebase preview deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -21,6 +21,7 @@ jobs:
       - run: yarn lint
       - run: yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BARKOCHBA_APP != '' }}
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BARKOCHBA_APP }}


### PR DESCRIPTION
## Summary
- Dependabot PRs don't have access to repository secrets, causing the Firebase hosting deploy step to fail with `Input required and not supplied: firebaseServiceAccount`
- Adds a condition to skip the deploy step when the secret is unavailable, while lint and build still run normally

## Test plan
- [ ] Verify existing PRs from repo contributors still get Firebase preview deploys
- [ ] Verify Dependabot PRs pass CI (lint + build) without failing on the deploy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)